### PR TITLE
Avoid users from being left out by the scheduling.

### DIFF
--- a/autonice.py
+++ b/autonice.py
@@ -115,7 +115,9 @@ def update_jobs(partition, total_cores, user):
             nice = NICE_VALUE_OVERUSE
         else:
             log("I am not overusing the grid! No need to be nice!")
-            nice = NICE_VALUE_FAIR_USE
+            max_penalty = (NICE_VALUE_OVERUSE - NICE_VALUE_FAIR_USE) / 2
+            running_jobs_penalty = max_penalty * my_usage.cores / fair_share
+            nice = NICE_VALUE_FAIR_USE + running_jobs_penalty
         set_pending_array_jobs_nice(partition, user, nice)
 
 


### PR DESCRIPTION
This idea is based on an issue I encountered when there were around 5 users with pending jobs. Since my task was deployed last, I had the lowest AGE value and generally my jobs had lower priority than all others. There was one user overusing his or her fair share by a factor of >2 and the tasks ran for more than a day. Due to the large amount of overuse by this person, It was possible for all other users except me to almost not overuse their share and they went in turn to be the person to overuse. Hence, usually the NICE value would be set to fair and due to the AGE value this meant that they would always be prioritized over me and my were never submitted.

My suggested fix for this problem is to weigh the "fair" NICE value depending on how much jobs the user is already running. Add a penalty of the following form to the standard fair NICE value: `penalty = max_penalty * my_usage.cores / fair_share'.
This results in users with fewer running jobs (or rather occupied cores) to have a lower NICE value and in turn having higher priority. Consequently, it is less likely to happen that a user is completely left out when deciding which job to start next.

Maybe this suggested update goes against the expected behavior of `autonice`. If not, I furthermore considered removing the distinction between "overusing" and "not overusing" completely and replacing the entire computation of the NICE value by a weighing dependent of the amount of occupied cores per user. Maybe I am missing something, but this seems quite reasonable to me.